### PR TITLE
refactor: modularize file plan generation

### DIFF
--- a/agents/fileplan_agent.py
+++ b/agents/fileplan_agent.py
@@ -1,41 +1,120 @@
 from __future__ import annotations
-from typing import Dict, Any, List
+
+import logging
+from dataclasses import asdict, dataclass
+from typing import Any, Dict, List
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class PlanFile:
+    """Represents a single file to be generated."""
+
+    path: str
+    role: str
+    depends_on: List[str]
+    contracts: List[str]
+
+
+def _validate_spec(spec: Dict[str, Any]) -> None:
+    """Ensure required sections exist in the specification."""
+
+    stacks = spec.get("stacks") or {}
+    if "backend" not in stacks or "frontend" not in stacks:
+        raise ValueError("spec must contain 'stacks.backend' and 'stacks.frontend'")
+
+
+def _backend_files(spec: Dict[str, Any]) -> List[PlanFile]:
+    be = spec["stacks"]["backend"]
+    be_fw = (be.get("framework") or "").lower()
+    be_lang = (be.get("lang") or "").lower()
+    files: List[PlanFile] = []
+
+    if be_fw in {"fastapi", "django"} or be_lang == "python":
+        files.extend(
+            [
+                PlanFile(
+                    "backend/app/main.py",
+                    "entrypoint",
+                    [],
+                    ["GET /health returns 200 {status:'ok'}"],
+                ),
+                PlanFile("backend/app/models/__init__.py", "pkg", [], []),
+                PlanFile("backend/app/routes/__init__.py", "pkg", [], []),
+                PlanFile(
+                    "tests/test_health.py",
+                    "test",
+                    ["backend/app/main.py"],
+                    ["GET /health == 200"],
+                ),
+                PlanFile("backend/requirements.txt", "deps", [], []),
+                PlanFile("pytest.ini", "test_config", [], []),
+            ]
+        )
+        for ent in spec.get("entities") or []:
+            ename = ent["name"].lower()
+            files.append(
+                PlanFile(
+                    f"backend/app/models/{ename}.py",
+                    "model",
+                    [],
+                    [f"Model for {ent['name']}",],
+                )
+            )
+            files.append(
+                PlanFile(
+                    f"backend/app/routes/{ename}s.py",
+                    "api",
+                    [f"backend/app/models/{ename}.py"],
+                    [f"CRUD for {ent['name']}",],
+                )
+            )
+
+    return files
+
+
+def _frontend_files(spec: Dict[str, Any]) -> List[PlanFile]:
+    fe = spec["stacks"]["frontend"]
+    fe_fw = (fe.get("framework") or "").lower()
+    fe_lang = (fe.get("lang") or "").lower()
+
+    if fe_fw == "react" and fe_lang == "ts":
+        return [
+            PlanFile("frontend/index.html", "page", [], ["Mounts #root"]),
+            PlanFile("frontend/src/main.tsx", "entry", [], ["Renders app title"]),
+            PlanFile("frontend/tsconfig.json", "tsconfig", [], []),
+            PlanFile("frontend/package.json", "deps", [], []),
+            PlanFile("frontend/vite.config.ts", "vite", [], []),
+        ]
+
+    return [
+        PlanFile("frontend/index.html", "page", [], ["Shows app title"]),
+    ]
+
+
+def _infra_files() -> List[PlanFile]:
+    return [
+        PlanFile(
+            "infra/docker-compose.yml",
+            "compose",
+            [],
+            ["api, frontend, db services"],
+        )
+    ]
+
 
 def spec_to_fileplan(spec: Dict[str, Any]) -> Dict[str, Any]:
-    files: List[Dict[str, Any]] = []
+    """Generate a file plan from a project specification."""
+
+    _validate_spec(spec)
     libs = spec.get("constraints", {}).get("allowed_libs", {})
-    be = spec["stacks"]["backend"]; be_fw = (be.get("framework") or "").lower(); be_lang = (be.get("lang") or "").lower()
-    fe = spec["stacks"]["frontend"]; fe_fw = (fe.get("framework") or "").lower(); fe_lang = (fe.get("lang") or "").lower()
 
-    # Backend (FastAPI default)
-    if be_fw in {"fastapi","django"} or be_lang == "python":
-        files += [
-            {"path":"backend/app/main.py","role":"entrypoint","depends_on":[],"contracts":["GET /health returns 200 {status:'ok'}"]},
-            {"path":"backend/app/models/__init__.py","role":"pkg","depends_on":[],"contracts":[]},
-            {"path":"backend/app/routes/__init__.py","role":"pkg","depends_on":[],"contracts":[]},
-            {"path":"tests/test_health.py","role":"test","depends_on":["backend/app/main.py"],"contracts":["GET /health == 200"]},
-            {"path":"backend/requirements.txt","role":"deps","depends_on":[],"contracts":[]},
-            {"path":"pytest.ini","role":"test_config","depends_on":[],"contracts":[]},
-        ]
-        for ent in (spec.get("entities") or []):
-            ename = ent["name"]
-            files += [
-                {"path":f"backend/app/models/{ename.lower()}.py","role":"model","depends_on":[],"contracts":[f"Model for {ename}"]},
-                {"path":f"backend/app/routes/{ename.lower()}s.py","role":"api","depends_on":[f"backend/app/models/{ename.lower()}.py"],"contracts":[f"CRUD for {ename}"]},
-            ]
+    files: List[PlanFile] = []
+    files.extend(_backend_files(spec))
+    files.extend(_frontend_files(spec))
+    files.extend(_infra_files())
 
-    # Frontend React TS default
-    if fe_fw=="react" and fe_lang=="ts":
-        files += [
-            {"path":"frontend/index.html","role":"page","depends_on":[],"contracts":["Mounts #root"]},
-            {"path":"frontend/src/main.tsx","role":"entry","depends_on":[],"contracts":["Renders app title"]},
-            {"path":"frontend/tsconfig.json","role":"tsconfig","depends_on":[],"contracts":[]},
-            {"path":"frontend/package.json","role":"deps","depends_on":[],"contracts":[]},
-            {"path":"frontend/vite.config.ts","role":"vite","depends_on":[],"contracts":[]},
-        ]
-    else:
-        files.append({"path":"frontend/index.html","role":"page","depends_on":[],"contracts":["Shows app title"]})
+    logger.debug("Generated %d file entries", len(files))
+    return {"files": [asdict(f) for f in files], "libraries": libs}
 
-    # Infra
-    files.append({"path":"infra/docker-compose.yml","role":"compose","depends_on":[],"contracts":["api, frontend, db services"]})
-    return {"files": files, "libraries": libs}


### PR DESCRIPTION
## Summary
- use a dataclass to represent plan entries
- validate spec structure and split generation into backend, frontend, and infra helpers
- add debug logging around file plan creation

## Testing
- `python -m py_compile agents/fileplan_agent.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bd6cf1220083338ab1f0dbff88a7e6