### PR TITLE
Enhance business rule extraction

### DIFF
--- a/agents/rules_agent.py
+++ b/agents/rules_agent.py
@@ -8,6 +8,42 @@ def _mk_id(n:int)->str: return f"BR-{n:04d}"
 _PAT_NEG = re.compile(r"(?i)\b(must|cannot|can't|should not|must not)\b.*\b(negative|less than\s*0)\b")
 _PAT_ENUM = re.compile(r"(?i)\b(status|state)\b.*\b(can be|allowed|one of)\b[: ]+([A-Za-z,\s|]+)")
 _PAT_EQ   = re.compile(r"(?i)^([A-Za-z_][\w\.]*)\s*=\s*(.+)$")
+_PAT_CMP  = re.compile(
+    r"(?i)\b([A-Za-z_][A-Za-z0-9_]*)\b[^\n]*?"  # field
+    r"(?:must|should|has to|needs to|cannot|can't|must not|should not)?[^\n]*?"
+    r"(at least|no less than|greater than or equal to|>=|more than|greater than|>|"
+    r"less than or equal to|<=|at most|no more than|not exceed|cannot exceed|"
+    r"must not exceed|should not exceed|less than|<)\s*(\d+(?:\.\d+)?)"
+)
+_PAT_UNIQUE = re.compile(
+    r"(?i)\b([A-Za-z_][A-Za-z0-9_]*)\b[^\n]*?"  # field
+    r"(?:must|should|has to|needs to)?[^\n]*?\bunique\b"
+)
+_PAT_NOT_EMPTY = re.compile(
+    r"(?i)\b([A-Za-z_][A-Za-z0-9_]*)\b[^\n]*?"  # field
+    r"(must|should|has to|needs to|cannot|can't|must not|should not)?[^\n]*?"
+    r"(not be empty|not be blank|be required|is required|required)"
+)
+
+_CMP_MAP = {
+    "at least": ">=",
+    "no less than": ">=",
+    "greater than or equal to": ">=",
+    ">=": ">=",
+    "more than": ">",
+    "greater than": ">",
+    ">": ">",
+    "less than": "<",
+    "<": "<",
+    "less than or equal to": "<=",
+    "<=": "<=",
+    "at most": "<=",
+    "no more than": "<=",
+    "not exceed": "<=",
+    "cannot exceed": "<=",
+    "must not exceed": "<=",
+    "should not exceed": "<=",
+}
 
 def _heuristic_rules(prd: str) -> List[Dict[str,Any]]:
     out: List[Dict[str,Any]] = []; n = 1
@@ -31,6 +67,51 @@ def _heuristic_rules(prd: str) -> List[Dict[str,Any]]:
             out.append({"id": _mk_id(n), "target": f"{field.capitalize()}.{field.lower()}",
                         "kind":"constraint", "expr": f"{field.lower()} in {options}",
                         "message": f"{field} must be one of {options}"}); n += 1
+            continue
+
+        m = _PAT_CMP.search(l)
+        if m:
+            field, comp, val = m.group(1), m.group(2), m.group(3)
+            op = _CMP_MAP.get(comp.lower(), ">=")
+            target = f"{field.capitalize()}.{field.lower()}"
+            msg = (
+                f"{field} {comp.lower()} {val}"
+                if comp.lower().startswith(("cannot", "must not", "should not", "not"))
+                else f"{field} must be {comp.lower()} {val}"
+            )
+            out.append({
+                "id": _mk_id(n),
+                "target": target,
+                "kind": "constraint",
+                "expr": f"{field.lower()} {op} {val}",
+                "message": msg,
+            }); n += 1
+            continue
+
+        m = _PAT_UNIQUE.search(l)
+        if m:
+            field = m.group(1)
+            target = f"{field.capitalize()}.{field.lower()}"
+            out.append({
+                "id": _mk_id(n),
+                "target": target,
+                "kind": "constraint",
+                "expr": f"unique({field.lower()})",
+                "message": f"{field} must be unique",
+            }); n += 1
+            continue
+
+        m = _PAT_NOT_EMPTY.search(l)
+        if m:
+            field = m.group(1)
+            target = f"{field.capitalize()}.{field.lower()}"
+            out.append({
+                "id": _mk_id(n),
+                "target": target,
+                "kind": "constraint",
+                "expr": f"{field.lower()} not in (None, '')",
+                "message": f"{field} must not be empty",
+            }); n += 1
             continue
 
         m = _PAT_EQ.match(l)


### PR DESCRIPTION
## Summary
- broaden rule regexes to capture comparative constraints, uniqueness, and required field conditions
- map natural language comparators to operators for constraint expressions
- extend heuristic extraction logic to emit rules for these new patterns

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bd6f908218833384716ddee7407ef5