### PR TITLE
Add traceback output in exception handlers

### DIFF
--- a/agents/requirements_agent.py
+++ b/agents/requirements_agent.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-import os, re, json
+import os, re, json, traceback
 from typing import List, Dict, Any
 
 def _mk_id(n:int)->str: return f"R-{n:04d}"
@@ -57,6 +57,7 @@ def extract_requirements(prd_text: str) -> List[Dict[str,Any]]:
             reqs = _llm_extract(prd_text)
             if not reqs: reqs=_heuristic_requirements(prd_text)
         except Exception:
+            traceback.print_exc()
             reqs=_heuristic_requirements(prd_text)
     else:
         reqs=_heuristic_requirements(prd_text)

--- a/agents/rules_agent.py
+++ b/agents/rules_agent.py
@@ -1,6 +1,6 @@
 # projectgen/agents/rules_agent.py
 from __future__ import annotations
-import os, re, json
+import os, re, json, traceback
 from typing import List, Dict, Any
 
 def _mk_id(n:int)->str: return f"BR-{n:04d}"
@@ -152,6 +152,7 @@ PRD:
             out.append(it)
         return out or _heuristic_rules(prd)
     except Exception:
+        traceback.print_exc()
         return _heuristic_rules(prd)
 
 def extract_rules(prd: str) -> List[Dict[str,Any]]:


### PR DESCRIPTION
## Summary
- print full stack traces when rule extraction fails
- expose tracebacks on requirement extraction errors
- show tracebacks during spec enrichment and PRD parsing

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bd8acc34ec833389dc8508b06ef49a