### PR TITLE
Preserve schema generation for routes

### DIFF
--- a/agents/fileplan_agent.py
+++ b/agents/fileplan_agent.py
@@ -53,6 +53,15 @@ def _backend_files(spec: Dict[str, Any]) -> List[PlanFile]:
                 PlanFile("pytest.ini", "test_config", [], []),
             ]
         )
+        if spec.get("entities"):
+            files.append(
+                PlanFile(
+                    "backend/app/routes/schemas.py",
+                    "schema",
+                    [],
+                    [],
+                )
+            )
         for ent in spec.get("entities") or []:
             ename = ent["name"].lower()
             files.append(


### PR DESCRIPTION
## Summary
- accumulate schema definitions for each route with requirement headers
- write combined schema file once and track it in generated files
- include generated schemas module in file plan so new file becomes part of project

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bd99bc33f08333934a579425662e35